### PR TITLE
Fixed inexistent path issue

### DIFF
--- a/Initializer.ps1
+++ b/Initializer.ps1
@@ -47,7 +47,7 @@ function Initialize-DefaultParams {
                 $config = Get-IniContent $configFilePath
             } else {
                 # Create the `.config` folder if it doesn't exist.
-                New-Item $configDirectoryPath -Type Directory > $null
+                New-Item $configDirectoryPath -Type Directory -ErrorAction SilentlyContinue > $null
 
                 # Create a default, empty config data.
                 $config = [ordered]@{


### PR DESCRIPTION
The current implementation throws this error:

```
"New-Item : Could not find a part of the path 'C:\Users\username\.config\manage-exchange_server.ini'.
At C:\Program Files\WindowsPowerShell\Modules\PsIni\3.1.2\Functions\Out-IniFile.ps1:186 char:24
+ ...      $outFile = New-Item -ItemType file -Path $Filepath -Force:$Force
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : WriteError: (C:\Users\UI1157...ange_server.ini:String) [New-Item], DirectoryNotFoundException
    + FullyQualifiedErrorId : NewItemIOError,Microsoft.PowerShell.Commands.NewItemCommand"
```

That is because the folder `.config` does not exist in `$HOME` on my machine and the `Out-IniFile` function would only create the file if it doesn't exist, but not the folder too.