### PR TITLE
Fix incorrect solution for the count error

### DIFF
--- a/Initializer.ps1
+++ b/Initializer.ps1
@@ -122,6 +122,10 @@ function Initialize-DefaultParams {
         $exchangeObjects = Read-Param "ExchangeObjects" `
             -Value $ExchangeObjects `
             -DefaultValue (Get-Content $inputFilePath -ErrorAction SilentlyContinue)
+
+        if ($null -eq $exchangeObjects) {
+            $exchangeObjects = @()
+        }
     }
 
     end {


### PR DESCRIPTION
This happened when no exchange object was loaded, because PowerShell
returns an empty array as `$null`:
https://stackoverflow.com/a/18477004/865175.

Reverts #43
Closes #48